### PR TITLE
Fix ruby build failure on the latest archlinux:base-devel image

### DIFF
--- a/.github/workflows/build-jekyll.yml
+++ b/.github/workflows/build-jekyll.yml
@@ -25,7 +25,7 @@ jobs:
             ${{ runner.os }}-gems-
 
       # Use GitHub Deploy Action to build and deploy to Github
-      - uses: jeffreytse/jekyll-deploy-action@v0.6.0
+      - uses: kkew3/jekyll-deploy-action@issue/ruby-3.1.3-break-on-archlinux
         with:
           provider: 'github'
           token: ${{ secrets.GITHUB_TOKEN }} # It's your Personal Access Token(PAT)

--- a/.github/workflows/build-jekyll.yml
+++ b/.github/workflows/build-jekyll.yml
@@ -35,7 +35,7 @@ jobs:
           jekyll_cfg: '_config.yml'  # Default is _config.yml
           jekyll_baseurl: ''         # Default is according to _config.yml
           bundler_ver: ''            # Default is compatible bundler version (~>2.5.0)
-          ruby_ver: '3.4.3'
+          ruby_ver: '3.3.0'
           cname: ''                  # Default is to not use a cname
           actor: 'github-actions[bot]' # Default is the GITHUB_ACTOR
           pre_build_commands: |

--- a/.github/workflows/build-jekyll.yml
+++ b/.github/workflows/build-jekyll.yml
@@ -35,7 +35,7 @@ jobs:
           jekyll_cfg: '_config.yml'  # Default is _config.yml
           jekyll_baseurl: ''         # Default is according to _config.yml
           bundler_ver: ''            # Default is compatible bundler version (~>2.5.0)
-          ruby_ver: '3.1.3'
+          ruby_ver: '3.4.3'
           cname: ''                  # Default is to not use a cname
           actor: 'github-actions[bot]' # Default is the GITHUB_ACTOR
           pre_build_commands: |

--- a/.github/workflows/build-jekyll.yml
+++ b/.github/workflows/build-jekyll.yml
@@ -35,7 +35,7 @@ jobs:
           jekyll_cfg: '_config.yml'  # Default is _config.yml
           jekyll_baseurl: ''         # Default is according to _config.yml
           bundler_ver: ''            # Default is compatible bundler version (~>2.5.0)
-          ruby_ver: '3.3.0'
+          ruby_ver: '3.2.0'
           cname: ''                  # Default is to not use a cname
           actor: 'github-actions[bot]' # Default is the GITHUB_ACTOR
           pre_build_commands: |

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ source "https://rubygems.org"
 gem "minima", "~> 2.5"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
-gem "github-pages", "~> 227", group: :jekyll_plugins
+gem "github-pages", "~> 232", group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"


### PR DESCRIPTION
Ruby 3.1.3 build failed on the latest archlinux:base-devel docker image, which is used in [jeffreytse/jekyll-deploy-action](https://github.com/jeffreytse/jekyll-deploy-action)@v0.6.0 github action.